### PR TITLE
Added functionality to convert from "str" and to "String

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ image = { version = "0.25", default-features = false, features = [
   "jpeg",
 ] }
 tokio = { version = "1", optional = true }
-strum = { version = "0.27", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"], optional = true }
 
 [features]
 async = [
@@ -23,6 +23,7 @@ async = [
   "tokio/rt-multi-thread",
   "tokio/time"
 ]
+strum = ["dep:strum"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ image = { version = "0.25", default-features = false, features = [
   "jpeg",
 ] }
 tokio = { version = "1", optional = true }
+strum = { version = "0.27", features = ["derive"] }
 
 [features]
 async = [

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,3 +1,5 @@
+use strum::{Display, EnumIter, EnumString};
+
 /// HIDAPI Vendor ID that Elgato products use
 pub const ELGATO_VENDOR_ID: u16 = 0x0fd9;
 
@@ -39,6 +41,7 @@ pub fn is_vendor_familiar(vendor: &u16) -> bool {
 
 /// Enum describing kinds of Stream Decks out there
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Display, EnumIter, EnumString)]
 pub enum Kind {
     /// First revision of original Stream Deck
     Original,

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "strum")]
 use strum::{Display, EnumIter, EnumString};
 
 /// HIDAPI Vendor ID that Elgato products use
@@ -41,7 +42,7 @@ pub fn is_vendor_familiar(vendor: &u16) -> bool {
 
 /// Enum describing kinds of Stream Decks out there
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[derive(Display, EnumIter, EnumString)]
+#[cfg_attr(feature = "strum", derive(Display, EnumIter, EnumString))]
 pub enum Kind {
     /// First revision of original Stream Deck
     Original,


### PR DESCRIPTION
Added functionality to:
1) convert from "str" to "Kind"-enum.
2) convert from "Kind"-enum to "String".
3) iterate over the "Kind" enums, as a bonus, just in case anybody would need it (e.g. to print a verbose message about the supported devices).

Newly added dependency: "strum" crate.
Reason: the enum "Kind" would still be the single single source of truth, any enums added/removed in the future would not necessitate further code changes for conversion purposes.

Closes #51 